### PR TITLE
feat: complete MVP - autostart, multi-platform CI, DX improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,20 @@ jobs:
             args: "--target aarch64-apple-darwin"
           - platform: "macos-13" # for Intel
             args: "--target x86_64-apple-darwin"
-          # Uncomment if you want to build for Windows/Linux
-          # - platform: 'ubuntu-22.04'
-          #   args: ''
-          # - platform: 'windows-latest'
-          #   args: ''
+          - platform: "ubuntu-22.04"
+            args: ""
+          - platform: "windows-latest"
+            args: ""
 
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: setup node
         uses: actions/setup-node@v4
@@ -40,7 +45,6 @@ jobs:
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          # Those targets are only used on macos runners so node-gyp doesn't have to be installed
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || matrix.platform == 'macos-13' && 'x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
@@ -56,7 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          tagName: app-v__VERSION__
           releaseName: "Timlyzer v__VERSION__"
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Timlyzer Makefile
 
-.PHONY: all dev build clean check lint help
+.PHONY: all dev build run clean check lint help
 
 # Default target
 all: help
@@ -18,6 +18,11 @@ build: ## Build the application for production
 
 build-debug: ## Build in debug mode
 	pnpm tauri build --debug
+
+run: ## Build, kill old instance, and launch the app for quick testing
+	pnpm tauri build
+	-pkill -x Timlyzer 2>/dev/null; sleep 1
+	open src-tauri/target/release/bundle/macos/Timlyzer.app
 
 # Quality Checks
 check: ## Check Rust code for errors

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "tailwind-merge": "^3.4.0",
     "zustand": "^5.0.9"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
     "@tauri-apps/cli": "^2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+onlyBuiltDependencies: '["esbuild"]'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,0 @@
-onlyBuiltDependencies: '["esbuild"]'

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -315,6 +315,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,11 +881,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -885,7 +916,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1009,7 +1040,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.10+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3307,6 +3338,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4052,7 +4094,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4103,7 +4145,7 @@ checksum = "17fcb8819fd16463512a12f531d44826ce566f486d7ccd211c9c8cebdaec4e08"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4173,6 +4215,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.10+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4448,6 +4504,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tokio",
@@ -4684,7 +4741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d5572781bee8e3f994d7467084e1b1fd7a93ce66bd480f8156ba89dee55a2b"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5657,6 +5714,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5687,7 +5753,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,9 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled"
   ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -533,6 +533,30 @@ pub fn export_to_json(
     })
 }
 // ============================================================================
+// Autostart Commands
+// ============================================================================
+
+/// Get autostart enabled status
+#[tauri::command]
+pub fn get_autostart(app: tauri::AppHandle) -> Result<bool, String> {
+    use tauri_plugin_autostart::ManagerExt;
+    let manager = app.autolaunch();
+    manager.is_enabled().map_err(|e: tauri_plugin_autostart::Error| e.to_string())
+}
+
+/// Set autostart enabled status
+#[tauri::command]
+pub fn set_autostart(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    use tauri_plugin_autostart::ManagerExt;
+    let manager = app.autolaunch();
+    if enabled {
+        manager.enable().map_err(|e: tauri_plugin_autostart::Error| e.to_string())
+    } else {
+        manager.disable().map_err(|e: tauri_plugin_autostart::Error| e.to_string())
+    }
+}
+
+// ============================================================================
 // System Commands
 // ============================================================================
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,10 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            Some(vec!["--minimized"]),
+        ))
         .setup(|app| {
             // Get app data directory
             let app_dir = app
@@ -106,6 +110,9 @@ pub fn run() {
             commands::export_to_csv,
             commands::export_to_json,
             commands::update_tray_menu,
+            // Autostart commands
+            commands::get_autostart,
+            commands::set_autostart,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/services/active_window.rs
+++ b/src-tauri/src/services/active_window.rs
@@ -46,7 +46,7 @@ const KNOWN_BROWSERS: &[&str] = &[
 
 /// Check if an app is a known browser
 fn is_browser(app_name: &str) -> bool {
-    KNOWN_BROWSERS.iter().any(|&b| app_name == b)
+    KNOWN_BROWSERS.contains(&app_name)
 }
 
 /// Get the URL from a browser using AppleScript (macOS only)

--- a/src-tauri/src/services/state_monitor.rs
+++ b/src-tauri/src/services/state_monitor.rs
@@ -166,7 +166,7 @@ fn get_idle_time_iokit() -> Option<Duration> {
     }
 
     unsafe {
-        let matching = IOServiceMatching(b"IOHIDSystem\0".as_ptr() as *const i8);
+        let matching = IOServiceMatching(c"IOHIDSystem".as_ptr());
         if matching.is_null() {
             log::warn!("Failed to create IOHIDSystem matching dictionary");
             return None;

--- a/src-tauri/src/services/tracker.rs
+++ b/src-tauri/src/services/tracker.rs
@@ -29,19 +29,6 @@ impl Default for TrackerConfig {
     }
 }
 
-/// Current tracking state
-#[derive(Debug, Clone, Default)]
-struct TrackingState {
-    /// Currently tracked window
-    current_window: Option<WindowInfo>,
-    /// Current AppTrackItem being built
-    current_app_item: Option<TrackItem>,
-    /// Current StatusTrackItem being built
-    current_status_item: Option<TrackItem>,
-    /// Last tracking time
-    last_track_time: i64,
-}
-
 /// Tracker service for automatic time tracking
 pub struct TrackerService {
     /// Reference to database
@@ -50,8 +37,6 @@ pub struct TrackerService {
     state_monitor: Arc<StateMonitor>,
     /// Tracker configuration
     config: RwLock<TrackerConfig>,
-    /// Current tracking state
-    state: RwLock<TrackingState>,
     /// Whether tracking is running
     is_running: Arc<AtomicBool>,
     /// Whether tracking is paused
@@ -70,7 +55,6 @@ impl TrackerService {
             db,
             state_monitor,
             config: RwLock::new(config),
-            state: RwLock::new(TrackingState::default()),
             is_running: Arc::new(AtomicBool::new(false)),
             is_paused: Arc::new(AtomicBool::new(false)),
         }

--- a/src/i18n/locales/en-US/settings.json
+++ b/src/i18n/locales/en-US/settings.json
@@ -46,7 +46,8 @@
     "db": {
       "title": "Database",
       "location": "Location",
-      "size": "Size"
+      "size": "Size",
+      "openLocation": "Open File Location"
     },
     "clear": {
       "title": "Clear Data",

--- a/src/i18n/locales/en-US/settings.json
+++ b/src/i18n/locales/en-US/settings.json
@@ -11,6 +11,8 @@
     "title": "Appearance",
     "theme": "Theme",
     "language": "Language",
+    "autostart": "Start on boot",
+    "autostartDesc": "Automatically start Timlyzer when you log in",
     "closeAction": "When closing window",
     "minimize": "Minimize to tray",
     "ask": "Ask every time",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -11,6 +11,8 @@
     "title": "外观",
     "theme": "主题",
     "language": "语言",
+    "autostart": "开机自启动",
+    "autostartDesc": "登录时自动启动 Timlyzer",
     "closeAction": "当关闭窗口时",
     "minimize": "最小化到托盘",
     "ask": "每次询问",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -46,7 +46,8 @@
     "db": {
       "title": "数据库",
       "location": "位置",
-      "size": "大小"
+      "size": "大小",
+      "openLocation": "打开文件位置"
     },
     "clear": {
       "title": "清除数据",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -18,6 +18,7 @@ import {
   Trash2,
   Palette,
   Info,
+  FolderOpen,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn, formatDuration } from "@/lib/utils";
@@ -33,6 +34,7 @@ import {
 import { appApi } from "@/services/tauri-api";
 import { format, subDays, startOfDay, endOfDay } from "date-fns";
 import { save } from "@tauri-apps/plugin-dialog";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
 
 type SettingsTab = "general" | "tracking" | "colors" | "data" | "about";
 
@@ -526,6 +528,17 @@ export function SettingsPage() {
                       </div>
                     </div>
                   </div>
+                  {dbInfo?.path && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-2"
+                      onClick={() => revealItemInDir(dbInfo.path)}
+                    >
+                      <FolderOpen className="w-4 h-4" />
+                      {t("data.db.openLocation")}
+                    </Button>
+                  )}
                 </CardContent>
               </Card>
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -25,6 +25,7 @@ import {
   settingsApi,
   exportApi,
   trackItemApi,
+  autostartApi,
   type TrackedApp,
   type DatabaseInfo,
   type AppSettings,
@@ -45,6 +46,7 @@ export function SettingsPage() {
   const [isExporting, setIsExporting] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [exportMessage, setExportMessage] = useState("");
+  const [autostartEnabled, setAutostartEnabled] = useState(false);
 
   // Load settings store for theme
   const { theme, setTheme } = useSettingsStore();
@@ -62,6 +64,10 @@ export function SettingsPage() {
       setDbInfo(info);
       setAppVersion(version);
       setSettings(settingsData);
+
+      // Load autostart status
+      const autostart = await autostartApi.isEnabled();
+      setAutostartEnabled(autostart);
     };
     loadData();
   }, []);
@@ -249,6 +255,36 @@ export function SettingsPage() {
                     ))}
                   </div>
                 </div>
+
+                {/* Autostart */}
+                <label className="flex items-center justify-between cursor-pointer">
+                  <div>
+                    <div className="font-medium">{t("appearance.autostart")}</div>
+                    <div className="text-sm text-slate-500">
+                      {t("appearance.autostartDesc")}
+                    </div>
+                  </div>
+                  <button
+                    onClick={async () => {
+                      const newValue = !autostartEnabled;
+                      await autostartApi.setEnabled(newValue);
+                      setAutostartEnabled(newValue);
+                    }}
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors",
+                      autostartEnabled
+                        ? "bg-primary-500"
+                        : "bg-slate-200 dark:bg-slate-700"
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "absolute top-1 w-4 h-4 rounded-full bg-white transition-transform",
+                        autostartEnabled ? "translate-x-6" : "translate-x-1"
+                      )}
+                    />
+                  </button>
+                </label>
 
                 {/* Close Action */}
                 <div>

--- a/src/services/tauri-api.ts
+++ b/src/services/tauri-api.ts
@@ -430,6 +430,35 @@ export const exportApi = {
 };
 
 // ============================================================================
+// Autostart API
+// ============================================================================
+
+export const autostartApi = {
+  /**
+   * Check if autostart is enabled
+   */
+  isEnabled: async (): Promise<boolean> => {
+    try {
+      return await invoke<boolean>("get_autostart");
+    } catch (error) {
+      console.error("getAutostart error:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Set autostart enabled/disabled
+   */
+  setEnabled: async (enabled: boolean): Promise<void> => {
+    try {
+      await invoke("set_autostart", { enabled });
+    } catch (error) {
+      console.error("setAutostart error:", error);
+    }
+  },
+};
+
+// ============================================================================
 // App control API
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- **开机自启动**: 集成 `tauri-plugin-autostart`，设置页面添加开关，支持 macOS LaunchAgent
- **多平台发布流水线**: release.yml 启用 Windows + Linux 构建矩阵（ubuntu-22.04, windows-latest）
- **打开数据库文件位置**: 设置 > 数据 > 数据库区域添加 "Open File Location" 按钮
- **`make run` target**: 构建 → kill 旧进程 → 启动新实例，一条命令快速测试
- **Clippy 警告清理**: 移除死代码、优化 `contains()` 调用、使用 `c""` 字面量

## Changed files (15 files, +215/-36)

| Area | Files |
|------|-------|
| Rust backend | `commands.rs`, `lib.rs`, `Cargo.toml`, `Cargo.lock` |
| Frontend | `SettingsPage.tsx`, `tauri-api.ts`, i18n (en/zh) |
| CI/CD | `release.yml` |
| DX | `Makefile` |
| Lint fixes | `active_window.rs`, `state_monitor.rs`, `tracker.rs` |
| Config | `capabilities/default.json`, `pnpm-workspace.yaml` |

## Test plan

- [x] `make lint` 零警告（tsc + cargo clippy）
- [x] `make run` 构建成功并启动应用
- [x] 设置 → 常规 → 开机自启动开关切换正常
- [x] 设置 → 数据 → "打开文件位置"按钮在 Finder 中定位 db 文件
- [ ] CI 三平台构建通过（macOS ARM/Intel, Ubuntu, Windows）

🤖 Generated with [Claude Code](https://claude.com/claude-code)