### PR TITLE
feat: add repository link to About page

### DIFF
--- a/src/i18n/locales/en-US/settings.json
+++ b/src/i18n/locales/en-US/settings.json
@@ -70,6 +70,7 @@
       "stats": "Statistics and reports",
       "export": "Data export"
     },
+    "repo": "GitHub Repository",
     "builtWith": "Built with Tauri + React",
     "createdBy": "Created by haxqer & isabel"
   },

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -70,6 +70,7 @@
       "stats": "统计与报表",
       "export": "数据导出"
     },
+    "repo": "GitHub 仓库",
     "builtWith": "基于 Tauri + React 构建",
     "createdBy": "由 haxqer & isabel 创建"
   },

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -34,7 +34,7 @@ import {
 import { appApi } from "@/services/tauri-api";
 import { format, subDays, startOfDay, endOfDay } from "date-fns";
 import { save } from "@tauri-apps/plugin-dialog";
-import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { revealItemInDir, openUrl } from "@tauri-apps/plugin-opener";
 
 type SettingsTab = "general" | "tracking" | "colors" | "data" | "about";
 
@@ -599,6 +599,18 @@ export function SettingsPage() {
                     <li>• {t("about.features.stats")}</li>
                     <li>• {t("about.features.export")}</li>
                   </ul>
+                </div>
+
+                <div className="border-t border-slate-200 dark:border-slate-700 pt-4">
+                  <button
+                    onClick={() => openUrl("https://github.com/Timlyzer/timlyzer")}
+                    className="flex items-center justify-center gap-2 w-full text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+                  >
+                    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                    </svg>
+                    {t("about.repo")}
+                  </button>
                 </div>
 
                 <div className="border-t border-slate-200 dark:border-slate-700 pt-4 text-center text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- Add a clickable GitHub repository link to the Settings > About page
- Uses `openUrl` from `@tauri-apps/plugin-opener` to open external links
- Added i18n translations (en-US / zh-CN)

## Test plan
- [ ] Open Settings > About tab
- [ ] Verify the GitHub repository link is displayed
- [ ] Click the link and verify it opens `https://github.com/Timlyzer/timlyzer` in the browser

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)