### PR TITLE
fix(ui): improve dark mode toggle and form control colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ build: ## Build the application for production
 build-debug: ## Build in debug mode
 	pnpm tauri build --debug
 
-run: ## Build, kill old instance, and launch the app for quick testing
-	pnpm tauri build
-	-pkill -x Timlyzer 2>/dev/null; sleep 1
-	open src-tauri/target/release/bundle/macos/Timlyzer.app
+run: ## Build release binary (no bundle), kill old instance, and launch
+	pnpm tauri build --no-bundle
+	-pkill -x Timlyzer 2>/dev/null; pkill -x timlyzer 2>/dev/null; sleep 1
+	./src-tauri/target/release/timlyzer
 
 # Quality Checks
 check: ## Check Rust code for errors

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-debug: ## Build in debug mode
 run: ## Build release binary (no bundle), kill old instance, and launch
 	pnpm tauri build --no-bundle
 	-pkill -x Timlyzer 2>/dev/null; pkill -x timlyzer 2>/dev/null; sleep 1
-	./src-tauri/target/release/timlyzer
+	./src-tauri/target/release/timlyzer &
 
 # Quality Checks
 check: ## Check Rust code for errors

--- a/src/index.css
+++ b/src/index.css
@@ -108,14 +108,21 @@ input[type="range"]::-moz-range-thumb {
 
 /* Radio Input */
 input[type="radio"] {
-  @apply w-4 h-4 text-slate-600 dark:text-green-500 border-slate-300 dark:border-slate-600;
-  @apply focus:ring-slate-500 dark:focus:ring-green-500 focus:ring-2;
+  @apply w-4 h-4 border-slate-300 dark:border-slate-500;
+  @apply focus:ring-2;
+  accent-color: theme('colors.slate.600');
 }
 
 /* Checkbox Input */
 input[type="checkbox"] {
-  @apply w-4 h-4 text-slate-600 dark:text-green-500 border-slate-300 dark:border-slate-600 rounded;
-  @apply focus:ring-slate-500 dark:focus:ring-green-500 focus:ring-2;
+  @apply w-4 h-4 border-slate-300 dark:border-slate-500 rounded;
+  @apply focus:ring-2;
+  accent-color: theme('colors.slate.600');
+}
+
+.dark input[type="radio"],
+.dark input[type="checkbox"] {
+  accent-color: theme('colors.green.500');
 }
 
 /* Text Input */

--- a/src/index.css
+++ b/src/index.css
@@ -108,14 +108,14 @@ input[type="range"]::-moz-range-thumb {
 
 /* Radio Input */
 input[type="radio"] {
-  @apply w-4 h-4 text-slate-600 border-slate-300 dark:border-slate-600;
-  @apply focus:ring-slate-500 focus:ring-2;
+  @apply w-4 h-4 text-slate-600 dark:text-green-500 border-slate-300 dark:border-slate-600;
+  @apply focus:ring-slate-500 dark:focus:ring-green-500 focus:ring-2;
 }
 
 /* Checkbox Input */
 input[type="checkbox"] {
-  @apply w-4 h-4 text-slate-600 border-slate-300 dark:border-slate-600 rounded;
-  @apply focus:ring-slate-500 focus:ring-2;
+  @apply w-4 h-4 text-slate-600 dark:text-green-500 border-slate-300 dark:border-slate-600 rounded;
+  @apply focus:ring-slate-500 dark:focus:ring-green-500 focus:ring-2;
 }
 
 /* Text Input */

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -277,8 +277,8 @@ export function SettingsPage() {
                     className={cn(
                       "relative w-11 h-6 rounded-full transition-colors",
                       autostartEnabled
-                        ? "bg-primary-500"
-                        : "bg-slate-200 dark:bg-slate-700"
+                        ? "bg-primary-500 dark:bg-green-500"
+                        : "bg-slate-300 dark:bg-slate-600 dark:ring-1 dark:ring-slate-400"
                     )}
                   >
                     <div
@@ -311,8 +311,8 @@ export function SettingsPage() {
                       className={cn(
                         "relative w-11 h-6 rounded-full transition-colors",
                         settings?.hideDock
-                          ? "bg-primary-500"
-                          : "bg-slate-200 dark:bg-slate-700"
+                          ? "bg-primary-500 dark:bg-green-500"
+                          : "bg-slate-300 dark:bg-slate-600 dark:ring-1 dark:ring-slate-400"
                       )}
                     >
                       <div
@@ -448,8 +448,8 @@ export function SettingsPage() {
                     className={cn(
                       "relative w-11 h-6 rounded-full transition-colors",
                       settings?.trackUrls
-                        ? "bg-primary-500"
-                        : "bg-slate-200 dark:bg-slate-700"
+                        ? "bg-primary-500 dark:bg-green-500"
+                        : "bg-slate-300 dark:bg-slate-600 dark:ring-1 dark:ring-slate-400"
                     )}
                   >
                     <div

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -335,26 +335,35 @@ export function SettingsPage() {
                       { value: "minimize", label: t("appearance.minimize") },
                       { value: "ask", label: t("appearance.ask") },
                       { value: "quit", label: t("appearance.quit") },
-                    ].map((option) => (
-                      <label
-                        key={option.value}
-                        className="flex items-center gap-2 cursor-pointer"
-                      >
-                        <input
-                          type="radio"
-                          name="closeAction"
-                          value={option.value}
-                          checked={settings?.closeAction === option.value}
-                          onChange={() =>
+                    ].map((option) => {
+                      const isSelected = settings?.closeAction === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() =>
                             setSettings((s) =>
                               s ? { ...s, closeAction: option.value } : s
                             )
                           }
-                          className="text-primary-500"
-                        />
-                        {option.label}
-                      </label>
-                    ))}
+                          className="flex items-center gap-2 cursor-pointer w-full text-left"
+                        >
+                          <div
+                            className={cn(
+                              "w-4 h-4 rounded-full border-2 flex items-center justify-center transition-colors",
+                              isSelected
+                                ? "border-slate-600 dark:border-green-500"
+                                : "border-slate-300 dark:border-slate-500"
+                            )}
+                          >
+                            {isSelected && (
+                              <div className="w-2 h-2 rounded-full bg-slate-600 dark:bg-green-500" />
+                            )}
+                          </div>
+                          {option.label}
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Toggle on-state uses `green-500` instead of `primary-500` (which is neutral gray) in dark mode
- Toggle off-state uses `slate-600` with `ring-1 ring-slate-400` border for visibility in dark mode
- Replace native radio with custom component (unaffected by window focus state)
- Unify all selected colors: `slate-600` (light) / `green-500` (dark) across toggles, radio, checkbox
- Use `accent-color` CSS property for remaining native form controls
- Optimize `make run`: use `--no-bundle` to skip DMG packaging for faster iteration

## Test plan
- [ ] Toggle on/off states clearly distinguishable in both light and dark mode
- [ ] Radio button color consistent with toggle on-state color
- [ ] Radio button color stays the same when window loses focus
- [ ] `make run` builds faster (no DMG) and launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)